### PR TITLE
Fix non sys targets

### DIFF
--- a/crowplexus/iris/Iris.hx
+++ b/crowplexus/iris/Iris.hx
@@ -106,7 +106,7 @@ class Iris {
 		Sys.println((posPrefix + ": " + out).stripColor());
 		#else
 		// Since non-sys targets lack printLn, a simple trace should work
-		trace(posPrefix + ": " + out);
+		trace((posPrefix + ": " + out).stripColor());
 		#end
 	}
 

--- a/crowplexus/iris/Iris.hx
+++ b/crowplexus/iris/Iris.hx
@@ -102,7 +102,12 @@ class Iris {
 				posPrefix = posPrefix.attr(INTENSITY_BOLD);
 			}
 		}
+		#if sys
 		Sys.println((posPrefix + ": " + out).stripColor());
+		#else
+		// Since non-sys targets lack printLn, a simple trace should work
+		trace(posPrefix + ": " + out);
+		#end
 	}
 
 	/**


### PR DESCRIPTION
Replaces the Sys.println function with a trace on build targets that cant access it (html5, etc)