### PR TITLE
using keyword extension

### DIFF
--- a/crowplexus/hscript/Interp.hx
+++ b/crowplexus/hscript/Interp.hx
@@ -966,14 +966,14 @@ class Interp {
 		};
 	}
 
-	function registerUsingLocal(cls: Class<Dynamic>, call: UsingCall): UsingEntry {
-		var entry = new UsingEntry(cls, call);
+	function registerUsingLocal(cls: Class<Dynamic>, call: UsingCall, ?check: UsingCheck): UsingEntry {
+		var entry = new UsingEntry(cls, call, check);
 		usings.push(entry);
 		return entry;
 	}
 
-	function registerUsingGlobal(cls: Class<Dynamic>, call: UsingCall): UsingEntry {
-		var entry = new UsingEntry(cls, call);
+	function registerUsingGlobal(cls: Class<Dynamic>, call: UsingCall, ?check: UsingCheck): UsingEntry {
+		var entry = new UsingEntry(cls, call, check);
 		allUsings.push(entry);
 		return entry;
 	}

--- a/tests/assets/stringtools.hx
+++ b/tests/assets/stringtools.hx
@@ -1,21 +1,34 @@
 package tests;
 
 // using test.world.Meow;
+using Util; // woo to recycling!
+
 function main() {
 	try {
 		"hello world".contains("hello");
 		trace("StringTools.contains should have thrown an error");
 	} catch (e:Dynamic) {}
-
+	
 	using StringTools;
 	try {
 		"hello world".contains("hello");
 	} catch (e:Dynamic) {
 		trace("StringTools.contains threw an error");
 	}
+	
+	try {
+		"hello world".hex(6);
+		trace("StringTools.hex should have thrown an error");
+	} catch (e:Dynamic) {}
+	
+	try {
+		0xFF0000.hex(6);
+	} catch (e:Dynamic) {
+		trace("StringTools.hex threw an error");
+	}
 
 	trace('i am going to die');
-
+	
 	trace('StringTools.startsWith("hello world", "hello")', StringTools.startsWith("hello world", "hello"));
 	trace('"hello world".startsWith("hello")', "hello world".startsWith("hello"));
 
@@ -27,9 +40,14 @@ function main() {
 
 	trace('StringTools.contains("hello world", "hello")', StringTools.contains("hello world", "hello"));
 	trace('"hello world".contains("hello")', "hello world".contains("hello"));
+	
+	// Util test
+	
+	trace('Util.repeatString("abc", 5)', Util.repeatString("abc", 5));
+	trace('"abc".repeatString(5)', "abc".repeatString(5));
 
 	// Lambda
-
+	
 	try {
 		var result = [1, 2, 3].findIndex(function(v) return v == 2);
 		trace("Lambda.findIndex should have thrown an error");
@@ -41,5 +59,16 @@ function main() {
 		var result = [1, 2, 3].findIndex(function(v) return v == 2);
 	} catch (e:Dynamic) {
 		trace("Lambda.findIndex threw an error");
+	}
+	
+	try {
+		var result = "hello world".find(function(v) return v > 10);
+		trace("Lambda.find should have thrown an error");
+	} catch (e:Dynamic) {}
+	
+	try {
+		var result = [1, 2, 3].find(function(v) return v > 10);
+	} catch (e:Dynamic) {
+		trace("Lambda.find threw an error");
 	}
 }


### PR DESCRIPTION
allows the static extension `using` keyword to be used for any class; also an attempt to improve its behavior
- using the keyword will also import the class, as intended
- prioritizes checking if a function exists on the object before checking if it exists in an extension
- also adds a type check function to UsingEntry, helpful to enhance currently existing entries in allUsings and also to prevent the interpreter from failing if a function has a null return value (ex. using Lambda, `<Iterable>.find` returning null if it doesn't find a matching item)

i also updated the stringtools test asset to reflect some of these changes